### PR TITLE
feat!: Require a single CI context ("ci")

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,7 @@ resource "github_branch_protection" "main" {
     strict = true
     contexts = concat(
       var.require_semantic_releases ? ["pr-ci / semantic-pr-title"] : [],
-      var.ci_contexts,
-      ["license/cla"]
+      ["ci", "license/cla"]
     )
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Other CI contexts can no longer be specified.